### PR TITLE
Testing branch als Firmwareauswahl anbieten

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -77,6 +77,19 @@
           '89e9df69a79e3e6a650daa3e8c0505f59b15b5dfd30167583e778ae7ce04a425', -- Ronny
         },
       },
+      testing = {
+        name = 'testing',
+        mirrors = {
+          'http://firmware.services.fffd/testing/current/sysupgrade',
+        },
+        good_signatures = 1, -- Jenkins will do it by default - allow others just in case
+        pubkeys = {
+          'd64c5603f8061b9293b4f4a0a9e9162e45a722851dd94047720716f8dfdee6f6', -- Jenkins (autobuild)
+          'e665f4aae305094105a27533e16a0139c15471ac646be8d81c6a44c01ed517e4', -- Sven
+          '448b7b9768b48883b7335dd7bcc4bcb2f21f28eea2ca126903ca81076eee5b91', -- Dustin
+          '89e9df69a79e3e6a650daa3e8c0505f59b15b5dfd30167583e778ae7ce04a425', -- Ronny
+        },
+      },
       development = {
         name = 'development',
         mirrors = {


### PR DESCRIPTION
"Testing" branch in der Freifunk-Fulda Konfiguration anbieten, wenn die Firmare aus "Testing" installiert wurde.

Issue: freifunk-fulda/orga#56
