### PR TITLE
Autoupdater in development deaktiviert

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -61,7 +61,7 @@
   },
 
   autoupdater = {
-    enabled = 1,
+    enabled = 0,
     branch = 'development',
     branches = {
       stable = {


### PR DESCRIPTION
Deaktivieren der autoupdater Funktion in Development.
Issue: freifunk-fulda/orga#57

Todo:
- [ ] Sicherstellen, dass site-fffd Referenz in gluon development branch für git submodule aktualisiert wird.
