### PR TITLE
issue/9 Build script erstellt

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # =====================================================================
-# Build script for Freifunk Fulda firmware runningn on Jenkinis CI
+# Build script for Freifunk Fulda firmware running on Jenkinis CI
 #
 # Source: https://github.com/freifunk-fulda
 # Contact: fffd-noc@lists.open-mail.net

--- a/build.sh
+++ b/build.sh
@@ -127,7 +127,6 @@ update() {
   for GLUON_TARGET in ${GLUON_TARGETS}; do
     make clean ${MAKEOPTS} GLUON_TARGET=${GLUON_TARGET}
   done
-
 }
 
 download() {

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,158 @@
+#!/bin/bash -e
+# =====================================================================
+# Build script for Freifunk Fulda firmware runningn on Jenkinis CI
+#
+# Source: https://github.com/freifunk-fulda
+# Contact: fffd-noc@lists.open-mail.net
+# Web: https://fulda.freifunk.net
+#
+# Credits:
+#   - Freifunk Darmstadt for your great support
+# =====================================================================
+
+# Default make options
+MAKEOPTS="-j 9 V=s"
+
+# Help function used in error messages and -h option
+usage() {
+  echo ""
+  echo "Build script for Freifunk-Fulda gluon firmware."
+  echo ""
+  echo "-c: Build command, [ update | download | build | sign | upload ]"
+  echo "-b: String for git branch, e.g. development"
+  echo "-d: Enable bash debug output"
+  echo "-h: Show this help"
+  echo "-m: Optional setting for make options. Default is \"-j 4\""
+  echo "-n: String for build number, e.g. b48"
+  echo "-w: Path for workspace, e.g. current work directoy"
+}
+
+# Evaluate arguments for build script.
+while getopts b:c:dhm:n:w: flag; do
+  case ${flag} in
+    b)
+      GIT_BRANCH=${OPTARG};
+      ;;
+    c)
+      case ${OPTARG} in
+        update)
+          export COMMAND=update
+          ;;
+        download)
+          export COMMAND=download
+          ;;
+        build)
+          export COMMAND=build
+          ;;
+        sign)
+          export COMMAND=sign
+          ;;
+        upload)
+          export COMMAND=upload
+          ;;
+        *)
+          echo "Error: Invalid build command set."
+          usage
+          exit 1
+          ;;
+      esac
+      ;;
+    d)
+      set -x
+      ;;
+    h)
+      usage
+      ;;
+    m)
+      MAKEOPTS=${OPTARG}
+      ;;
+    n)
+      BUILD_NUMBER=${OPTARG}
+      ;;
+    w)
+      WORKSPACE=${OPTARG};
+      ;;
+    ?)
+      usage
+      exit;
+      ;;
+    *)
+      usage
+      exit;
+      ;;
+  esac
+done
+
+shift $(( OPTIND - 1 ));
+
+# Sanity checks for required arguments
+if [ -z "${GIT_BRANCH}" ]; then
+  echo "Error: Git branch with -b is not set."
+  usage
+  exit 1
+fi
+
+if [ -z "${BUILD_NUMBER}" ]; then
+  echo "Error: Build number with -n is not set."
+  usage
+  exit 1
+fi
+
+if [ -z "${WORKSPACE}" ]; then
+  WORKSPACE=$(readlink -e $(dirname $0))
+fi
+
+if [ -z "${COMMAND}" ]; then
+  echo "Error: Build command with -c is not set."
+  usage
+  exit 1
+fi
+
+# Use the root project as site-config for make commands below
+export GLUON_SITEDIR="${WORKSPACE}"
+
+# Configure gluon build
+export GLUON_BRANCH="${GIT_BRANCH#origin/}"            # Use the current git branch as autoupdate branch
+export GLUON_BUILD="${BUILD_NUMBER}-$(date '+%Y%m%d')" # ... and generate a fency build identifier
+export GLUON_RELEASE="${GLUON_BRANCH}-${GLUON_BUILD}"
+export GLUON_PRIORITY=1                                # Number of days that may pass between releasing an updating
+export GLUON_TARGETS="ar71xx-generic ar71xx-nand mpc85xx-generic x86-generic x86-kvm_guest"
+
+# Specify deployment credentials
+export DEPLOYMENT_SERVER="firmware.fulda.freifunk.net"
+export DEPLOYMENT_USER="deployment"
+
+update() {
+  make update ${MAKEOPTS}
+  for GLUON_TARGET in ${GLUON_TARGETS}; do
+    make clean ${MAKEOPTS} GLUON_TARGET=${GLUON_TARGET}
+  done
+
+}
+
+download() {
+  for GLUON_TARGET in ${GLUON_TARGETS}; do
+    make download ${MAKEOPTS} GLUON_TARGET=${GLUON_TARGET}
+  done
+}
+
+build() {
+  for GLUON_TARGET in ${GLUON_TARGETS}; do
+    make ${MAKEOPTS} GLUON_TARGET=${GLUON_TARGET}
+  done
+}
+
+sign() {
+  contrib/sign.sh ~/freifunk/autoupdate_secret_jenkins images/sysupgrade/${GLUON_BRANCH}.manifest
+}
+
+upload() {
+  ssh -i ~/.ssh/deploy_id_rsa -o stricthostkeychecking=no -p 22022 ${DEPLOYMENT_USER}@${DEPLOYMENT_SERVER} "mkdir -p firmware/${GLUON_BRANCH}/${GLUON_BUILD}"
+  scp -i ~/.ssh/deploy_id_rsa -o stricthostkeychecking=no -P 22022 -r images/* ${DEPLOYMENT_USER}@${DEPLOYMENT_SERVER}:firmware/${GLUON_BRANCH}/${GLUON_BUILD}
+  ssh -i ~/.ssh/deploy_id_rsa -o stricthostkeychecking=no -p 22022 ${DEPLOYMENT_USER}@${DEPLOYMENT_SERVER} "ln -sf -T ${GLUON_BUILD} firmware/${GLUON_BRANCH}/current"
+}
+
+(
+  cd gluon
+  ${COMMAND}
+)

--- a/sign.sh
+++ b/sign.sh
@@ -1,0 +1,80 @@
+#!/bin/bash -ex
+# =====================================================================
+# Downloads, signs and uploads a gluon manifest file.
+#
+# This is used by firmware developers to sign a release after it was
+# uploaded by the build system.
+#
+# Source: https://github.com/freifunk-fulda
+# Contact: fffd-noc@lists.open-mail.net
+# Web: https://fulda.freifunk.net
+#
+# Credits:
+#   - Freifunk Darmstadt for your great support
+# =====================================================================
+
+# Basic configuration
+SRV_USER="root"
+SRV_HOST="firmware.fulda.freifunk.net"
+SRV_PORT=22022
+SRV_PATH="/var/www/downloads.freifunk-fulda.de/firmware"
+
+# Help function used in error messages and -h option
+usage() {
+  echo ""
+  echo "Downloads, signs and uploads a gluon manifest file."
+  echo "Usage ./sign.sh KEY_PATH BRANCH"
+  echo "    PUBKEY      the path to the developers prvate key"
+  echo "    BRANCH      the branch to sign"
+}
+
+# Evaluate arguments for build script.
+if [[ "${#}" != 2 ]]; then
+  echo "Insufficient arguments given"
+  usage
+  exit 1
+fi
+
+PUBKEY="${1}"
+BRANCH="${2}"
+
+# Sanity checks for required arguments
+if [[ ! -e "${PUBKEY}" ]]; then
+  echo "Error: Key file not found or not readable: ${KEY_PATH}"
+  usage
+  exit 1
+fi
+
+if [[ -z "${BRANCH}" ]]; then
+  echo "Error: Invalid branch name: ${BRANCH}"
+  usage
+  exit 1
+fi
+
+# Check if ecdsa utils are installed
+if ! which ecdsasign 2> /dev/null; then
+  echo "ecdsa utils are not found."
+  exit 1
+fi
+
+# Determine temporary local file
+TMP="$(mktemp)"
+
+# Download manifest
+scp \
+  -o stricthostkeychecking=no \
+  -P "${SRV_PORT}" \
+  "${SRV_USER}@${SRV_HOST}:${SRV_PATH}/${BRANCH}/current/sysupgrade/${BRANCH}.manifest" \
+  "${TMP}"
+
+# Sign the local file
+./gluon/contrib/sign.sh \
+  "${PUBKEY}" \
+  "${TMP}"
+
+# Upload signed file
+scp \
+  -o stricthostkeychecking=no \
+  -P "${SRV_PORT}" \
+  "${TMP}" \
+  "${SRV_USER}@${SRV_HOST}:${SRV_PATH}/${BRANCH}/current/sysupgrade/${BRANCH}.manifest"

--- a/site.conf
+++ b/site.conf
@@ -95,7 +95,7 @@
         mirrors = {
           'http://firmware.services.fffd/stable/current/sysupgrade',
         },
-        good_signatures = 2, -- Jenkins will do one - somebody must do the second
+        good_signatures = 3, -- Jenkins will do one - somebody must do the second
         pubkeys = {
           'd64c5603f8061b9293b4f4a0a9e9162e45a722851dd94047720716f8dfdee6f6', -- Jenkins (autobuild)
           'e665f4aae305094105a27533e16a0139c15471ac646be8d81c6a44c01ed517e4', -- Sven


### PR DESCRIPTION
Build script erlaubt es firmware lokal mit den gleichen parametern zu erstellen
wie auf dem Jenkins build system. Zusaetzlich koennen in jedem Gluon build step
unterschiedliche anzahlen von make build jobs gesetzt werden. Falls beim download
server nicht erreicht werden, kann ein paralleler Build Probleme verursachen.
Zusaetzlich wurde ein sign.sh script erstellt um Firmware signatur zu vereinfachen.
