### PR TITLE
Add Firmware-Support for Fujitsu Futro S550

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "gluon"]
 	path = gluon
 	url = https://github.com/freifunk-fulda/gluon.git
-	branch = development
+	branch = issue/95

--- a/i18n/de.po
+++ b/i18n/de.po
@@ -32,3 +32,18 @@ msgstr ""
 "und Infos zu speziellen Diensten im Freifunk-Netz findest Du auf unserer Webseite "
 "<a href=\"https://fulda.freifunk.net\">https://fulda.freifunk.net</a>.</p> "
 "<p>Viel Spa&szlig; mit Deinem Freifunk-Knoten und der Erkundung von Freifunk!</p>"
+
+msgid "gluon-luci-node-role:role:node"
+msgstr "Normaler Knoten"
+
+msgid "gluon-luci-node-role:role:backbone"
+msgstr "Backbone-Knoten"
+
+msgid "gluon-luci-node-role:role:service"
+msgstr "Service-Knoten"
+
+msgid "gluon-luci-node-role:role:offloader"
+msgstr "Offloader-Knoten"
+
+msgid "gluon-luci-node-role:role:test"
+msgstr "Test-Knoten"

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -30,3 +30,18 @@ msgstr ""
 "to contact Freifunk Fulda and our services can be found on our webpage: "
 "<a href=\"http://fulda.freifunk.net\">http://fulda.freifunk.net</a>.</p>"
 "<p>We hope you will enjoy our Freifunk network!</p>"
+
+msgid "gluon-luci-node-role:role:node"
+msgstr "Normal Node"
+
+msgid "gluon-luci-node-role:role:backbone"
+msgstr "Backbone Node"
+
+msgid "gluon-luci-node-role:role:service"
+msgstr "Service Node"
+
+msgid "gluon-luci-node-role:role:offloader"
+msgstr "Offloader Node"
+
+msgid "gluon-luci-node-role:role:test"
+msgstr "Test Node"

--- a/site.conf
+++ b/site.conf
@@ -138,4 +138,15 @@
       limit_ingress = 5000,
     },
   },
+
+  roles = {
+    default = 'node',
+    list = {
+      'node',
+      'backbone',
+      'service',
+      'offloader',
+      'test',
+    },
+  },
 }

--- a/site.mk
+++ b/site.mk
@@ -19,6 +19,7 @@ GLUON_SITE_PACKAGES := \
   gluon-luci-portconfig \
   gluon-luci-private-wifi \
   gluon-luci-mesh-vpn-fastd \
+  gluon-luci-node-role \
   gluon-next-node \
   gluon-mesh-vpn-fastd \
   gluon-radvd \

--- a/site.mk
+++ b/site.mk
@@ -29,6 +29,18 @@ GLUON_SITE_PACKAGES := \
   iptables \
   haveged
 
+# Support (USB) network interfaces on x86 devices
+ifeq ($(GLUON_TARGET),x86-generic)
+GLUON_SITE_PACKAGES += \
+  kmod-usb-core \
+  kmod-usb2 \
+  kmod-usb-hid \
+  kmod-usb-net \
+  kmod-usb-net-asix \
+  kmod-usb-net-dm9601-ether \
+  kmod-r8169
+endif
+
 # Allow overriding the release number from the command line
 GLUON_RELEASE ?= snapshot-$(shell date '+%Y%m%d%H%M%S')
 


### PR DESCRIPTION
As described in https://github.com/freifunk-fulda/orga/issues/95.

This adds the required modules to the build and changed the kernel config to support the PATA controller.

Note: This required a change to the gluon tree. Therefore the reference to the submodule was changed and must be reset while merging.
