### PR TITLE
Use random BSSID for mesh WiFi

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -18,7 +18,7 @@
     channel = 1,
     htmode = 'HT40+',
     mesh_ssid = '00:00:ff:fd:00:11',
-    mesh_bssid = '00:00:ff:fd:00:11',
+    mesh_bssid = 'ce:7b:9d:f9:fc:5d',
     mesh_mcast_rate = 12000,
     aliases = {
       'freifunk.net',
@@ -30,7 +30,7 @@
     channel = 44,
     htmode = 'HT40+',
     mesh_ssid = '00:00:ff:fd:00:12',
-    mesh_bssid = '00:00:ff:fd:00:12',
+    mesh_bssid = 'ce:7b:9d:f9:fc:5d',
     mesh_mcast_rate = 12000,
     aliases = {
       'freifunk.net',


### PR DESCRIPTION
As described in https://github.com/freifunk-fulda/orga/issues/7.
