### PR TITLE
changed internal dns to fffd.eu

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -8,8 +8,8 @@
 
   timezone = 'CET-1CEST,M3.5.0,M10.5.0/3', -- Europe/Berlin
   ntp_servers = {
-    'ntp1.services.fffd',
-    'ntp2.services.fffd',
+    'ntp1.services.fffd.eu',
+    'ntp2.services.fffd.eu',
   },
   regdom = 'DE',
 
@@ -92,7 +92,7 @@
       stable = {
         name = 'stable',
         mirrors = {
-          'http://firmware.services.fffd/stable/current/sysupgrade',
+          'http://firmware.services.fffd.eu/stable/current/sysupgrade',
         },
         good_signatures = 3, -- Jenkins will do one - somebody must do the second
         pubkeys = {
@@ -107,7 +107,7 @@
       testing = {
         name = 'testing',
         mirrors = {
-          'http://firmware.services.fffd/testing/current/sysupgrade',
+          'http://firmware.services.fffd.eu/testing/current/sysupgrade',
         },
         good_signatures = 1, -- Jenkins will do it by default - allow others just in case
         pubkeys = {
@@ -122,7 +122,7 @@
       development = {
         name = 'development',
         mirrors = {
-          'http://firmware.services.fffd/development/current/sysupgrade',
+          'http://firmware.services.fffd.eu/development/current/sysupgrade',
         },
         good_signatures = 1, -- Jenkins will do it by default - allow others just in case
         pubkeys = {


### PR DESCRIPTION
As described in freifunk-fulda/orga#72 we changed the internal domain from fffd to fffd.eu
So the entries for ntp and firmware have to be changed.
