### PR TITLE
Enable Firmware Build for ath10k based devices in gluon 2016.2.x

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -57,4 +57,4 @@ GLUON_LANGS ?= en de
 BROKEN = 1
 
 # Enable Firmware Build for ath10k-based 5GHz WLAN Devices for example Archer c5 and c7 Modellsö
-GLUON_ATH10K_MESH = ibs
+GLUON_ATH10K_MESH = ibss

--- a/site.mk
+++ b/site.mk
@@ -56,5 +56,5 @@ GLUON_LANGS ?= en de
 # Enable hardware with broken support
 BROKEN = 1
 
-# Enable Firmware Build for ath10k-based 5GHz WLAN Devices for example Archer c5 and c7 Modellsö
+# Enable Firmware Build for ath10k-based 5GHz WLAN Devices for example Archer c5 and c7 Modells by using ibss Mesh only
 GLUON_ATH10K_MESH = ibss

--- a/site.mk
+++ b/site.mk
@@ -56,5 +56,5 @@ GLUON_LANGS ?= en de
 # Enable hardware with broken support
 BROKEN = 1
 
-# Enable Firmware Build ath10k-based 5GHz WLAN Devices for example Archer c5 and c7 Modellsö
+# Enable Firmware Build for ath10k-based 5GHz WLAN Devices for example Archer c5 and c7 Modellsö
 GLUON_ATH10K_MESH = ibs

--- a/site.mk
+++ b/site.mk
@@ -55,3 +55,6 @@ GLUON_LANGS ?= en de
 
 # Enable hardware with broken support
 BROKEN = 1
+
+# Enable Firmware Build ath10k-based 5GHz WLAN Devices for example Archer c5 and c7 Modellsö
+GLUON_ATH10K_MESH = ibs


### PR DESCRIPTION
This enables the firmware build for devices like the TP-Link Archer c5 and c7, which are now supported by gluon it self with setting this flag to use ibss meshing
